### PR TITLE
handle too many requests response error

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,19 @@
+from unittest import mock
+
+import httpx
+import pytest
+
+from toggl_python import ReportTimeEntries, TokenAuth
+from toggl_python.exceptions import TooManyRequests
+
+
+def test_raises_too_many_requests():
+    auth = TokenAuth("token")
+    report_time_entries_api = ReportTimeEntries(auth=auth)
+    with mock.patch.object(
+        report_time_entries_api.client,
+        "get",
+        mock.MagicMock(__name__="get", return_value=httpx.Response(status_code=429, text="test")),
+    ):
+        with pytest.raises(TooManyRequests):
+            report_time_entries_api.list()

--- a/toggl_python/api.py
+++ b/toggl_python/api.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Optional
 import httpx
 
 from .auth import BasicAuth, TokenAuth
-from .exceptions import STATUS_2_EXCEPTION
+from .exceptions import raise_from_response
 
 
 class Api:
@@ -78,8 +78,7 @@ class Api:
                 headers=self.HEADERS,
             )
         )
-        if response.status_code == httpx.codes.OK:
-            return response
-        else:
-            exception_class = STATUS_2_EXCEPTION[response.status_code]
-            raise exception_class(response.text)
+
+        raise_from_response(response)
+
+        return response

--- a/toggl_python/exceptions.py
+++ b/toggl_python/exceptions.py
@@ -1,3 +1,6 @@
+import httpx
+
+
 class TogglException(Exception):
     pass
 
@@ -26,10 +29,24 @@ class NotSupported(TogglException):
     pass
 
 
+class TooManyRequests(TogglException):
+    pass
+
+
 STATUS_2_EXCEPTION = {
     400: BadRequest,
     401: Unauthorized,
     403: Forbidden,
     404: NotFound,
     405: MethodNotAllowed,
+    429: TooManyRequests,
 }
+
+
+def raise_from_response(response: httpx.Response) -> None:
+    """Raise exception based on the response status code."""
+    if response.status_code < 400:
+        return
+
+    exception_cls = STATUS_2_EXCEPTION.get(response.status_code, TogglException)
+    raise exception_cls(response.text)


### PR DESCRIPTION
* raise TooManyRequests exception if response with 429 status code is returned
* raise base exception if unknown response status code is received