### PR TITLE
Switched to api.track.toggl.com

### DIFF
--- a/toggl_python/api.py
+++ b/toggl_python/api.py
@@ -16,7 +16,7 @@ class Api:
     Allow to interact with official Toggl API via httpx.
     """
 
-    BASE_URL: httpx.URL = httpx.URL("https://www.toggl.com/api/v8/")
+    BASE_URL: httpx.URL = httpx.URL("https://api.track.toggl.com/api/v8/")
     HEADERS = {
         "content-type": "application/json",
         "user_agent": "toggl-python",

--- a/toggl_python/repository.py
+++ b/toggl_python/repository.py
@@ -234,7 +234,7 @@ class TimeEntries(BaseRepository):
 
 
 class ReportTimeEntries(BaseRepository):
-    BASE_URL: httpx.URL = httpx.URL("https://toggl.com/reports/api/v2/")
+    BASE_URL: httpx.URL = httpx.URL("https://api.track.toggl.com/reports/api/v2/")
     ADDITIONAL_PARAMS = {"list": {"user_agent": "toggl_python"}}
     DATA_CONTAINER = {"list": "data"}
     LIST_URL = "details"


### PR DESCRIPTION
Switched to api.track.toggl.com, deprecated api url is not working anymore.